### PR TITLE
Fix the plugin copy bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ dev/
 _build/
 temp/
 whitebox/__MACOSX/
+**/.DS_Store
 
 # C extensions
 *.so

--- a/examples/whitebox.ipynb
+++ b/examples/whitebox.ipynb
@@ -85,7 +85,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 1,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -103,11 +103,39 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 2,
             "metadata": {
                 "scrolled": true
             },
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "WhiteboxTools Help\n",
+                        "\n",
+                        "The following commands are recognized:\n",
+                        "--cd, --wd          Changes the working directory; used in conjunction with --run flag.\n",
+                        "--compress_rasters  Sets the compress_raster option in the settings.json file; determines if newly created rasters are compressed. e.g. --compress_rasters=true\n",
+                        "-h, --help          Prints help information.\n",
+                        "-l, --license       Prints the whitebox-tools license. Tool names may also be used, --license=\"Slope\"\n",
+                        "--listtools         Lists all available tools. Keywords may also be used, --listtools slope.\n",
+                        "--max_procs         Sets the maximum number of processors used. -1 = all available processors. e.g. --max_procs=2\n",
+                        "-r, --run           Runs a tool; used in conjunction with --wd flag; -r=\"LidarInfo\".\n",
+                        "--toolbox           Prints the toolbox associated with a tool; --toolbox=Slope.\n",
+                        "--toolhelp          Prints the help associated with a tool; --toolhelp=\"LidarInfo\".\n",
+                        "--toolparameters    Prints the parameters (in json form) for a specific tool; --toolparameters=\"LidarInfo\".\n",
+                        "-v                  Verbose mode. Without this flag, tool outputs will not be printed.\n",
+                        "--viewcode          Opens the source code of a tool in a web browser; --viewcode=\"LidarInfo\".\n",
+                        "--version           Prints the version information.\n",
+                        "\n",
+                        "Example Usage:\n",
+                        ">> ./whitebox_tools -r=lidar_info --cd=\"/path/to/data/\" -i=input.las --vlr --geokeys\n",
+                        "\n",
+                        "\n"
+                    ]
+                }
+            ],
             "source": [
                 "print(wbt.help())"
             ]
@@ -121,11 +149,36 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 3,
             "metadata": {
                 "scrolled": false
             },
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "WhiteboxTools License\n",
+                        "Copyright 2017-2023 John Lindsay\n",
+                        "\n",
+                        "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and\n",
+                        "associated documentation files (the \"Software\"), to deal in the Software without restriction,\n",
+                        "including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,\n",
+                        "and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,\n",
+                        "subject to the following conditions:\n",
+                        "\n",
+                        "The above copyright notice and this permission notice shall be included in all copies or substantial\n",
+                        "portions of the Software.\n",
+                        "\n",
+                        "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT\n",
+                        "NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n",
+                        "NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES\n",
+                        "OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN\n",
+                        "CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+                        "\n"
+                    ]
+                }
+            ],
             "source": [
                 "print(wbt.license())"
             ]
@@ -139,9 +192,22 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 4,
             "metadata": {},
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Version information: WhiteboxTools v2.4.0 (c) Dr. John Lindsay 2017-2023\n",
+                        "\n",
+                        "WhiteboxTools is an advanced geospatial data analysis platform developed at\n",
+                        "the University of Guelph's Geomorphometry and Hydrogeomatics Research \n",
+                        "Group (GHRG). See www.whiteboxgeo.com for more details.\n",
+                        "\n"
+                    ]
+                }
+            ],
             "source": [
                 "print(\"Version information: {}\".format(wbt.version()))"
             ]
@@ -155,13 +221,25 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 16,
             "metadata": {
                 "scrolled": true
             },
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "thread 'main' panicked at whitebox-tools-app/src/main.rs:72:21:\n",
+                        "Unrecognized tool name Conditionedlatinhypercube.\n",
+                        "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n",
+                        "\n"
+                    ]
+                }
+            ],
             "source": [
-                "print(wbt.tool_help(\"ElevPercentile\"))"
+                "print(wbt.tool_help(\"ConditionedLatinHypercube\"))\n",
+                "print(wbt.tool_help(\"lidar_info\"))"
             ]
         },
         {
@@ -170,6 +248,13 @@
             "source": [
                 "**Tool names in the whitebox Python package can be called either using the snake_case or CamelCase convention (e.g. lidar_info or LidarInfo). The example below uses snake_case.** "
             ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": []
         },
         {
             "cell_type": "code",
@@ -664,7 +749,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.9"
+            "version": "3.11.9"
         }
     },
     "nbformat": 4,

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -140,11 +140,13 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
                 shutil.rmtree(new_img_dir)
             if os.path.exists(new_plugin_dir):
                 shutil.rmtree(new_plugin_dir)
+            if os.path.exists(new_plugin_dir):
+                shutil.rmtree(new_plugin_dir)
 
-            if os.path.exists(new_img_dir):
+            if os.path.exists(init_img_dir):
                 shutil.copytree(init_img_dir, new_img_dir)
 
-            if os.path.exists(new_plugin_dir):
+            if os.path.exists(init_plugin_dir):
                 shutil.copytree(init_plugin_dir, new_plugin_dir)
 
             if os.path.exists(zip_dir):
@@ -154,13 +156,13 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
                 exe_ext = ".exe"
             exe_name = "whitebox_tools{}".format(exe_ext)
             exe_path = os.path.join(exe_dir, exe_name)
-            # runner_name = "whitebox_runner{}".format(exe_ext)
-            # runner_path = os.path.join(exe_dir, runner_name)
+            runner_name = "whitebox_runner{}".format(exe_ext)
+            runner_path = os.path.join(exe_dir, runner_name)
 
             # grant executable permission
             if platform.system() != "Windows":
                 os.system("chmod 755 " + exe_path)
-                # os.system("chmod 755 " + runner_path)
+                os.system("chmod 755 " + runner_path)
             plugins = list(
                 set(glob.glob(os.path.join(new_plugin_dir, "*")))
                 - set(glob.glob(os.path.join(new_plugin_dir, "*.json")))
@@ -171,8 +173,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
 
             exe_path_new = os.path.join(pkg_dir, exe_name)
             shutil.copy(exe_path, exe_path_new)
-            # runner_path_new = os.path.join(pkg_dir, runner_name)
-            # shutil.copy(runner_path, runner_path_new)
+            runner_path_new = os.path.join(pkg_dir, runner_name)
+            shutil.copy(runner_path, runner_path_new)
 
             try:
                 os.remove(zip_name)

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -164,7 +164,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             # grant executable permission
             if platform.system() != "Windows":
                 os.system("chmod 755 " + exe_path)
-                os.system("chmod 755 " + runner_path)
+                if os.path.exists(runner_path):
+                    os.system("chmod 755 " + runner_path)
             plugins = list(
                 set(glob.glob(os.path.join(new_plugin_dir, "*")))
                 - set(glob.glob(os.path.join(new_plugin_dir, "*.json")))

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -89,10 +89,12 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             # Download WhiteboxTools
             try:
                 request = urllib.request.urlopen(url, timeout=500)
+                print("Downloading WhiteboxTools binary from {}".format(url))
             except urllib.error.URLError as e:
                 print(e)
                 print("Trying backup link ...")
                 url = backup_links[platform.system()]
+                print("Downloading WhiteboxTools binary from {}".format(url))
                 request = urllib.request.urlopen(url, timeout=500)
 
             with open(zip_name, "wb") as f:

--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -174,7 +174,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             exe_path_new = os.path.join(pkg_dir, exe_name)
             shutil.copy(exe_path, exe_path_new)
             runner_path_new = os.path.join(pkg_dir, runner_name)
-            shutil.copy(runner_path, runner_path_new)
+            if os.path.exists(runner_path):
+                shutil.copy(runner_path, runner_path_new)
 
             try:
                 os.remove(zip_name)

--- a/whitebox/whitebox_tools.py
+++ b/whitebox/whitebox_tools.py
@@ -169,11 +169,13 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
                 shutil.rmtree(new_img_dir)
             if os.path.exists(new_plugin_dir):
                 shutil.rmtree(new_plugin_dir)
+            if os.path.exists(new_plugin_dir):
+                shutil.rmtree(new_plugin_dir)
 
-            if os.path.exists(new_img_dir):
+            if os.path.exists(init_img_dir):
                 shutil.copytree(init_img_dir, new_img_dir)
 
-            if os.path.exists(new_plugin_dir):
+            if os.path.exists(init_plugin_dir):
                 shutil.copytree(init_plugin_dir, new_plugin_dir)
 
             if os.path.exists(zip_dir):
@@ -183,13 +185,13 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
                 exe_ext = ".exe"
             exe_name = "whitebox_tools{}".format(exe_ext)
             exe_path = os.path.join(exe_dir, exe_name)
-            # runner_name = "whitebox_runner{}".format(exe_ext)
-            # runner_path = os.path.join(exe_dir, runner_name)
+            runner_name = "whitebox_runner{}".format(exe_ext)
+            runner_path = os.path.join(exe_dir, runner_name)
 
             # grant executable permission
             if platform.system() != "Windows":
                 os.system("chmod 755 " + exe_path)
-                # os.system("chmod 755 " + runner_path)
+                os.system("chmod 755 " + runner_path)
             plugins = list(
                 set(glob.glob(os.path.join(new_plugin_dir, "*")))
                 - set(glob.glob(os.path.join(new_plugin_dir, "*.json")))
@@ -200,8 +202,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
 
             exe_path_new = os.path.join(pkg_dir, exe_name)
             shutil.copy(exe_path, exe_path_new)
-            # runner_path_new = os.path.join(pkg_dir, runner_name)
-            # shutil.copy(runner_path, runner_path_new)
+            runner_path_new = os.path.join(pkg_dir, runner_name)
+            shutil.copy(runner_path, runner_path_new)
 
             try:
                 os.remove(zip_name)

--- a/whitebox/whitebox_tools.py
+++ b/whitebox/whitebox_tools.py
@@ -203,7 +203,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             exe_path_new = os.path.join(pkg_dir, exe_name)
             shutil.copy(exe_path, exe_path_new)
             runner_path_new = os.path.join(pkg_dir, runner_name)
-            shutil.copy(runner_path, runner_path_new)
+            if os.path.exists(runner_path):
+                shutil.copy(runner_path, runner_path_new)
 
             try:
                 os.remove(zip_name)

--- a/whitebox/whitebox_tools.py
+++ b/whitebox/whitebox_tools.py
@@ -193,7 +193,8 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             # grant executable permission
             if platform.system() != "Windows":
                 os.system("chmod 755 " + exe_path)
-                os.system("chmod 755 " + runner_path)
+                if os.path.exists(runner_path):
+                    os.system("chmod 755 " + runner_path)
             plugins = list(
                 set(glob.glob(os.path.join(new_plugin_dir, "*")))
                 - set(glob.glob(os.path.join(new_plugin_dir, "*.json")))

--- a/whitebox/whitebox_tools.py
+++ b/whitebox/whitebox_tools.py
@@ -118,10 +118,12 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
             # Download WhiteboxTools
             try:
                 request = urllib.request.urlopen(url, timeout=500)
+                print("Downloading WhiteboxTools binary from {}".format(url))
             except urllib.error.URLError as e:
                 print(e)
                 print("Trying backup link ...")
                 url = backup_links[platform.system()]
+                print("Downloading WhiteboxTools binary from {}".format(url))
                 request = urllib.request.urlopen(url, timeout=500)
 
             with open(zip_name, "wb") as f:


### PR DESCRIPTION
This PR fixes the bug reported in #67. It copies the `plugin` folder from the WBT folder to the package folder. 