### PR TITLE
Make WBT download optional

### DIFF
--- a/whitebox/download_wbt.py
+++ b/whitebox/download_wbt.py
@@ -18,6 +18,9 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
     import pkg_resources
     import webbrowser
 
+    if os.environ.get("WBT_PATH", None) is not None:
+        return
+
     # print("Your operating system: {}".format(platform.system()))
     package_name = "whitebox"
     # Get package directory

--- a/whitebox/whitebox_tools.py
+++ b/whitebox/whitebox_tools.py
@@ -47,6 +47,9 @@ def download_wbt(linux_musl=False, reset=False, verbose=True):
     import pkg_resources
     import webbrowser
 
+    if os.environ.get("WBT_PATH", None) is not None:
+        return
+
     # print("Your operating system: {}".format(platform.system()))
     package_name = "whitebox"
     # Get package directory


### PR DESCRIPTION
Fix #72 

If the environment variable `WBT_PATH` is detected, the WBT download will be skipped, making it possible to use WBT offline. 